### PR TITLE
Exchangable Menus

### DIFF
--- a/include/draw_delegator.hpp
+++ b/include/draw_delegator.hpp
@@ -9,7 +9,6 @@ namespace UI
      * but does not perform a draw action themselves.
      *
      * This class needs to be inherited by another class.
-     * Also, the consumed drawable needs to be owned by inheritor.
      */ 
     class DrawDelegator : public Widget
     {

--- a/include/draw_delegator.hpp
+++ b/include/draw_delegator.hpp
@@ -1,0 +1,22 @@
+#pragma  once
+
+#include "widget.hpp"
+
+namespace UI
+{
+    /* 
+     * A DrawDelegator class contains elements that can be drawn,
+     * but does not perform a draw action themselves.
+     *
+     * This class needs to be inherited by another class.
+     * Also, the consumed drawable needs to be owned by inheritor.
+     */ 
+    class DrawDelegator : public Widget
+    {
+        public:
+            DrawDelegator(Widget * const parent);
+
+            virtual void redraw(TFT_eSprite &drawBuffer, const Rect &clientArea) const override;
+            virtual void draw(TFT_eSprite &drawBuffer, const Rect &clientArea) const override;
+    };
+}

--- a/include/menu.hpp
+++ b/include/menu.hpp
@@ -104,7 +104,7 @@ void espMenuEventHandler(
 		}
 	    }
 
-	    ~Menu();
+	    virtual ~Menu();
 
 	    void makeActive();
 

--- a/include/menu.hpp
+++ b/include/menu.hpp
@@ -9,6 +9,7 @@
 #include <list>
 #include <vector>
 #include <memory>
+#include <functional>
 
 #include <esp_event.h>
 
@@ -59,22 +60,52 @@ namespace UI {
 
     };
 
-    class VerticalMenu: public AbstractMenuBar, public Widget
+    class Menu
+    {
+	using EventHandler = typename std::function<
+	    void(AbstractMenuBar&, UI::AbstractMenuBar::EventData const&)
+	>;
+	public:
+	    template<class MenuBarClass, class... Args>
+	    Menu(
+		EventHandler menuEventHandler,
+		Widget * const parent,
+		Args... menuBarArgs) :
+		    menuBar_(std::move(
+			std::make_unique<MenuBarClass>(menuBarArgs..., this))),
+		    menuEventHandler_(menuEventHandler),
+		    parent_(parent) {}
+	    
+	    ~Menu();
+
+	private:
+	    std::unique_ptr<AbstractMenuBar> menuBar_;
+	    EventHandler menuEventHandler_;
+	    Widget * const parent_;
+
+	    void onEvent(
+	        void *event_handler_arg,
+        	esp_event_base_t event_base,
+                int32_t event_id,
+                void *event_data);
+    };
+
+    class VerticalMenuBar: public AbstractMenuBar, public Widget
     {
         public:
-            explicit VerticalMenu(const AbstractMenuBar::MenuItems &menuItems,
+            explicit VerticalMenuBar(const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
                         unsigned selected,
                         Widget * const parent
                         );
-            explicit VerticalMenu(const AbstractMenuBar::MenuItems &menuItems,
+            explicit VerticalMenuBar(const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
                         Theme const& theme,
                         unsigned selected,
                         Widget * const parent
                         );
 
-            ~VerticalMenu();
+            ~VerticalMenuBar();
 
             void selectNext() override;
             void selectPrevious() override;

--- a/include/menu.hpp
+++ b/include/menu.hpp
@@ -87,9 +87,9 @@ void espMenuEventHandler(
 	public:
 	    template<class MenuBarClass, class... Args>
 	    Menu(
-		std::in_place_type_t<MenuBarClass>,
 		EventHandler menuEventHandler,
 		Widget * const parent,
+		std::in_place_type_t<MenuBarClass>,
 		Args... menuBarArgs) :
 		    DrawDelegator(parent),
 		    menuBar_(std::move(

--- a/include/menu.hpp
+++ b/include/menu.hpp
@@ -53,6 +53,9 @@ void espMenuEventHandler(
         virtual String selectedItem() const { return items_[selectedItem_]; }
         virtual unsigned selectedIndex() const {return selectedItem_; }
 
+	virtual void setHandleInput(bool useInput);
+	virtual bool isHandlingInput() const;
+
         protected:
 
         MenuItems items_;
@@ -68,7 +71,6 @@ void espMenuEventHandler(
         private:
         void onKeyboardEvent(UsbKeyboard::Events event);
         static void keyboardEventHandler( void* event_handler_arg, esp_event_base_t event_base,  int32_t event_id, void* event_data);
-
     };
 
     class Menu : public DrawDelegator

--- a/include/widget.hpp
+++ b/include/widget.hpp
@@ -26,13 +26,15 @@ namespace UI {
 
         void moveTo(int x, int y) { area_.x = x; area_.y = y; }
 
+	Widget const * getSibling() const {return nextSibling_;}
+
         protected:
         virtual void draw(TFT_eSprite &drawBuffer, const Rect &clientArea) const;
 
         Rect area_;
         Widget * parent_;
         Widget * child_;
-        Widget * nextSibbling_;
+        Widget * nextSibling_;
         Color faceColor_;
 	bool hidden_;
     };

--- a/include/widget.hpp
+++ b/include/widget.hpp
@@ -21,6 +21,9 @@ namespace UI {
 
         virtual void setTheme(Theme const& theme) { faceColor_ = theme.colors.background; }
 
+	void setHidden(bool hidden) { hidden_ = hidden; }
+	bool isHidden() { return hidden_; }
+
         void moveTo(int x, int y) { area_.x = x; area_.y = y; }
 
         protected:
@@ -31,5 +34,6 @@ namespace UI {
         Widget * child_;
         Widget * nextSibbling_;
         Color faceColor_;
+	bool hidden_;
     };
 }

--- a/src/AbstractMenuBar.cpp
+++ b/src/AbstractMenuBar.cpp
@@ -4,10 +4,14 @@ ESP_EVENT_DEFINE_BASE(MENU_EVENT);
 
 namespace UI
 {
-    AbstractMenuBar::AbstractMenuBar(const std::vector<String> &menuItems,
-                                     unsigned selected):
-                                     items_(menuItems),
-                                     selectedItem_(selected)
+    AbstractMenuBar::AbstractMenuBar(
+		    	const AbstractMenuBar::MenuItems &menuItems,
+                        Rect area,
+                        unsigned selected,
+                        Widget * const parent) :
+	    		    Widget(area, parent),
+                            items_(menuItems),
+                            selectedItem_(selected)
     {
         esp_event_handler_register(KEYBOARD_EVENT,
                                    ESP_EVENT_ANY_ID,

--- a/src/AbstractMenuBar.cpp
+++ b/src/AbstractMenuBar.cpp
@@ -1,9 +1,12 @@
 #include "menu.hpp"
 
+
 ESP_EVENT_DEFINE_BASE(MENU_EVENT);
 
 namespace UI
 {
+    static AbstractMenuBar const * currentMenubarHandlingInput_ = nullptr;
+
     AbstractMenuBar::AbstractMenuBar(
 		    	const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
@@ -13,17 +16,12 @@ namespace UI
                             items_(menuItems),
                             selectedItem_(selected)
     {
-        esp_event_handler_register(KEYBOARD_EVENT,
-                                   ESP_EVENT_ANY_ID,
-                                   AbstractMenuBar::keyboardEventHandler,
-                                   this);
+        // empty
     }
 
     AbstractMenuBar::~AbstractMenuBar()
     {
-        esp_event_handler_unregister(KEYBOARD_EVENT,
-                                     ESP_EVENT_ANY_ID,
-                                     AbstractMenuBar::keyboardEventHandler);
+        setHandleInput(false);
     }
 
     unsigned AbstractMenuBar::firstItemToDisplay() const
@@ -75,6 +73,35 @@ namespace UI
         esp_event_post(MENU_EVENT, ItemSelected, &data, sizeof(EventData), 0);
     }
 
+    void AbstractMenuBar::setHandleInput(bool useInput)
+    {
+        if (currentMenubarHandlingInput_ != this)
+        {
+            if (useInput)
+            {
+                esp_event_handler_register(KEYBOARD_EVENT,
+                                           ESP_EVENT_ANY_ID,
+                                           AbstractMenuBar::keyboardEventHandler,
+                                           this);
+                currentMenubarHandlingInput_ = this;
+            }
+        }
+        else 
+        {
+            if (!useInput)
+            {
+                esp_event_handler_unregister(KEYBOARD_EVENT,
+                                             ESP_EVENT_ANY_ID,
+                                             AbstractMenuBar::keyboardEventHandler);
+                currentMenubarHandlingInput_ = nullptr;
+            }
+        }
+    }
+
+    bool AbstractMenuBar::isHandlingInput() const
+    {
+        return currentMenubarHandlingInput_ == this;
+    }
 
     void AbstractMenuBar::onKeyboardEvent(UsbKeyboard::Events event)
     {

--- a/src/VerticalMenuBar.cpp
+++ b/src/VerticalMenuBar.cpp
@@ -2,7 +2,7 @@
 
 namespace UI {
 
-VerticalMenu::VerticalMenu(const AbstractMenuBar::MenuItems &menuItems,
+VerticalMenuBar::VerticalMenuBar(const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
                         unsigned selected = 0,
                         Widget * const parent = nullptr
@@ -20,17 +20,17 @@ VerticalMenu::VerticalMenu(const AbstractMenuBar::MenuItems &menuItems,
     updateDisplayedLabels();
 }
 
-VerticalMenu::VerticalMenu(const AbstractMenuBar::MenuItems &menuItems,
+VerticalMenuBar::VerticalMenuBar(const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
                         Theme const& theme,
                         unsigned selected = 0,
                         Widget * const parent = nullptr
-                        ): VerticalMenu(menuItems, area, selected, parent)
+                        ): VerticalMenuBar(menuItems, area, selected, parent)
 {
     setTheme(theme);
 }
 
-VerticalMenu::~VerticalMenu()
+VerticalMenuBar::~VerticalMenuBar()
 {
     /*All this is not needed but I feel better that way*/
     menuLabel_.clear();
@@ -39,24 +39,24 @@ VerticalMenu::~VerticalMenu()
     downLabel_.reset();
 }
 
-unsigned VerticalMenu::itemsOnDisplay() const
+unsigned VerticalMenuBar::itemsOnDisplay() const
 {
     return area_.height;
 }
 
-void VerticalMenu::selectNext()
+void VerticalMenuBar::selectNext()
 {
     AbstractMenuBar::selectNext();
     updateDisplayedLabels();
 }
 
-void VerticalMenu::selectPrevious()
+void VerticalMenuBar::selectPrevious()
 {
     AbstractMenuBar::selectPrevious();
     updateDisplayedLabels();
 }
 
-void VerticalMenu::updateDisplayedLabels()
+void VerticalMenuBar::updateDisplayedLabels()
 {
     for(auto label: menuLabel_)
     {
@@ -92,7 +92,7 @@ void VerticalMenu::updateDisplayedLabels()
     }
 }
 
-void VerticalMenu::setTheme(Theme const& theme)
+void VerticalMenuBar::setTheme(Theme const& theme)
 {
     Widget::setTheme(theme);
     for (std::shared_ptr<Label> menuLabel : menuLabel_)

--- a/src/VerticalMenuBar.cpp
+++ b/src/VerticalMenuBar.cpp
@@ -6,8 +6,7 @@ VerticalMenuBar::VerticalMenuBar(const AbstractMenuBar::MenuItems &menuItems,
                         Rect area,
                         unsigned selected = 0,
                         Widget * const parent = nullptr
-                        ): AbstractMenuBar(menuItems, selected),
-                           Widget(area, parent)
+                        ): AbstractMenuBar(menuItems, area, selected, parent)
 {
     for(unsigned i=0; i< itemsOnDisplay(); ++i)
     {

--- a/src/draw_delegator.cpp
+++ b/src/draw_delegator.cpp
@@ -1,0 +1,26 @@
+#include "draw_delegator.hpp"
+#include "widget.hpp"
+
+using namespace UI;
+
+DrawDelegator::DrawDelegator(Widget * const parent) :
+    Widget(Rect(), parent)
+{
+    // empty
+}
+
+void DrawDelegator::redraw(TFT_eSprite &drawBuffer, const Rect &clientArea) const
+{
+    if (hidden_) return;
+
+    Widget const * child = child_;
+    while (child) {
+        child->redraw(drawBuffer, clientArea);
+        child = child->getSibling();
+    }
+}
+
+void DrawDelegator::draw(TFT_eSprite&, const Rect&) const
+{
+    // no-op
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ static void setupThemedElements(
 	UI::Application * const parent)
 {
     statusBar = new Statusbar(0, theme, parent);
-    typekeyMenu = new UI::Menu( UI::VerticalMenu,
+    typekeyMenu = new UI::Menu(
         [](
 	    UI::AbstractMenuBar& menuBar,
 	    UI::AbstractMenuBar::EventData const& eventData)
@@ -82,7 +82,8 @@ static void setupThemedElements(
             keyboard->sendKeyStrokes(file);
 	},
 	parent,
-	/* VerticalMenuBar args from here */
+	/* VerticalMenuBar initialization starting from here */
+	UI::VerticalMenu,
 	items,
 	UI::Rect(0, 1, screen.width, screen.height - 1),
 	theme,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 static UI::Application *application;
 static UI::Menu * typekeyMenu;
+static UI::Menu * etcMenu;
 static Statusbar *statusBar;
 static SDCard *sdCard;
 static UI::AbstractMenuBar::MenuItems menuItems;
@@ -89,14 +90,39 @@ static void setupThemedElements(
 	theme,
 	0
     );
+    etcMenu = new UI::Menu(
+        [](
+	    UI::AbstractMenuBar& menuBar,
+	    UI::AbstractMenuBar::EventData const& eventData)
+	{
+	    if (menuBar.selectedItem() ==  "mount")
+	    {
+	    }
+	    else if (menuBar.selectedItem() ==  "unmount")
+	    {
+	    }
+	    else if (menuBar.selectedItem() ==  "convert")
+	    {
+	    }
+	},
+	parent,
+	/* VerticalMenuBar initialization starting from here */
+	UI::VerticalMenu,
+	UI::AbstractMenuBar::MenuItems{"mount", "unmount", "convert"},
+	UI::Rect(0, 1, screen.width, screen.height - 1),
+	theme,
+	0
+    );
+
     typekeyMenu->makeActive();
+    etcMenu->makeActive();
 }
 
 
 void setup()
 {
     esp_event_loop_create_default();
-    esp_event_handler_register(KEYBOARD_EVENT,UsbKeyboard::LedsUpdated, onLedUpdate, NULL);
+    esp_event_handler_register(KEYBOARD_EVENT, UsbKeyboard::LedsUpdated, onLedUpdate, NULL);
 
     sdCard = new SDCard();
     loadDirectoryContent();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 
 static UI::Application *application;
 static UI::Menu * typekeyMenu;
-static UI::Menu * etcMenu;
 static Statusbar *statusBar;
 static SDCard *sdCard;
 static UI::AbstractMenuBar::MenuItems menuItems;
@@ -79,8 +78,8 @@ static void setupThemedElements(
 	    UI::AbstractMenuBar& menuBar,
 	    UI::AbstractMenuBar::EventData const& eventData)
 	{
-            KeyStrokeFile file(sdCard->open(menuBar.selectedItem(), SDCard::OpenMode::FILE_READONLY));
-            keyboard->sendKeyStrokes(file);
+	    KeyStrokeFile file(sdCard->open(menuBar.selectedItem(), SDCard::OpenMode::FILE_READONLY));
+	    keyboard->sendKeyStrokes(file);
 	},
 	parent,
 	/* VerticalMenuBar initialization starting from here */
@@ -90,32 +89,7 @@ static void setupThemedElements(
 	theme,
 	0
     );
-    etcMenu = new UI::Menu(
-        [](
-	    UI::AbstractMenuBar& menuBar,
-	    UI::AbstractMenuBar::EventData const& eventData)
-	{
-	    if (menuBar.selectedItem() ==  "mount")
-	    {
-	    }
-	    else if (menuBar.selectedItem() ==  "unmount")
-	    {
-	    }
-	    else if (menuBar.selectedItem() ==  "convert")
-	    {
-	    }
-	},
-	parent,
-	/* VerticalMenuBar initialization starting from here */
-	UI::VerticalMenu,
-	UI::AbstractMenuBar::MenuItems{"mount", "unmount", "convert"},
-	UI::Rect(0, 1, screen.width, screen.height - 1),
-	theme,
-	0
-    );
-
     typekeyMenu->makeActive();
-    etcMenu->makeActive();
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
 #include "macros.hpp"
 
 static UI::Application *application;
-static UI::VerticalMenu *vmenu;
+static UI::VerticalMenuBar *vmenu;
 static Statusbar *statusBar;
 static SDCard *sdCard;
 static UI::AbstractMenuBar::MenuItems menuItems;
@@ -91,7 +91,7 @@ static void setupThemedElements(
 	UI::Application * parent)
 {
     statusBar = new Statusbar(0, theme, parent);
-    vmenu = new UI::VerticalMenu(items,
+    vmenu = new UI::VerticalMenuBar(items,
 				 UI::Rect(0,1,screen.width, screen.height - 1),
 				 theme,
 				 0,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,27 +41,6 @@ static void loadDirectoryContent(void)
   }
 }
 
-#if 0
-static void onMenuSelected(void *event_handler_arg,
-                           esp_event_base_t event_base,
-                           int32_t event_id,
-                           void *event_data)
-{
-   if(event_base == MENU_EVENT)
-   {
-      UI::AbstractMenuBar::EventData *eventData = reinterpret_cast<UI::AbstractMenuBar::EventData*>(event_data);
-
-      if(eventData)
-      {
-        if(eventData->self == vmenu)
-        {
-            KeyStrokeFile file(sdCard->open(vmenu->selectedItem(), SDCard::OpenMode::FILE_READONLY));
-            keyboard->sendKeyStrokes(file);
-        }
-      }
-   }
-}
-#endif
 
 static void onLedUpdate(void *event_handler_arg,
                            esp_event_base_t event_base,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ static void setupThemedElements(
 	UI::Theme const& theme,
 	UI::Rect const& screen,
 	UI::AbstractMenuBar::MenuItems const& items,
-	UI::Application * parent)
+	UI::Application * const parent)
 {
     statusBar = new Statusbar(0, theme, parent);
     typekeyMenu = new UI::Menu( UI::VerticalMenu,

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -22,25 +22,7 @@ void UI::espMenuEventHandler(
 
 Menu::~Menu()
 {
-#if 0
-	if (parent_) {
-	    Widget * previousChild = nullptr;
-	    Widget * child = parent_->child_;
-
-	    while(child && child != this) {
-		previousChild = child;
-		child = child ->nextSibbling_;
-	    }
-
-	    if(previousChild && child) {
-		previousChild ->nextSibbling_ = nextSibbling_;
-	    } else if( child ) {
-		parent_->child_ = nextSibbling_;
-	    } // else the child was not found which would be an
-	      // inconsistency error and should never happen
-	}
-#endif
-	menus_.erase(this);
+    menus_.erase(this);
 }
 
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -15,7 +15,10 @@ void UI::espMenuEventHandler(
     // of a function ptr
     for (Menu* menu : Menu::menus_)
     {
-        menu->onEvent(event_handler_arg, event_base, event_id, event_data);
+	if (!menu->isHidden())
+	{
+            menu->onEvent(event_handler_arg, event_base, event_id, event_data);
+	}
     }
 };
 
@@ -50,6 +53,8 @@ void Menu::makeActive()
     for (Menu* menu : menus_)
     {
 	menu->menuBar_->setHidden(true);
+        menu->menuBar_->setHandleInput(false);
     }
     menuBar_->setHidden(false);
+    menuBar_->setHandleInput(true);
 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,19 +1,48 @@
 #include "menu.hpp"
 
 using namespace UI;
-#if 0
-Menu::Menu(
-    AbstractMenuBar const& menuBar,
-    Menu::EventHandler menuEventHandler) :
-	menuBar_(menuBar),
-	menuEventHandler_(menuEventHandler)
-{ /*empty*/ }
-#endif
+
+std::set<Menu*> Menu::menus_;
+
+void UI::espMenuEventHandler(
+    void *event_handler_arg,
+    esp_event_base_t event_base,
+    int32_t event_id,
+    void *event_data)
+{
+    // Use this to delegate the call because
+    // a bound member function cannot be used in place
+    // of a function ptr
+    for (Menu* menu : Menu::menus_)
+    {
+        menu->onEvent(event_handler_arg, event_base, event_id, event_data);
+    }
+};
+
 
 Menu::~Menu()
 {
+#if 0
+	if (parent_) {
+	    Widget * previousChild = nullptr;
+	    Widget * child = parent_->child_;
 
+	    while(child && child != this) {
+		previousChild = child;
+		child = child ->nextSibbling_;
+	    }
+
+	    if(previousChild && child) {
+		previousChild ->nextSibbling_ = nextSibbling_;
+	    } else if( child ) {
+		parent_->child_ = nextSibbling_;
+	    } // else the child was not found which would be an
+	      // inconsistency error and should never happen
+	}
+#endif
+	menus_.erase(this);
 }
+
 
 void Menu::onEvent(
     void *event_handler_arg,
@@ -31,4 +60,14 @@ void Menu::onEvent(
    	    menuEventHandler_(*menuBar_, *eventData);
       	}
    }
+}
+
+
+void Menu::makeActive()
+{
+    for (Menu* menu : menus_)
+    {
+	menu->menuBar_->setHidden(true);
+    }
+    menuBar_->setHidden(false);
 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,0 +1,34 @@
+#include "menu.hpp"
+
+using namespace UI;
+#if 0
+Menu::Menu(
+    AbstractMenuBar const& menuBar,
+    Menu::EventHandler menuEventHandler) :
+	menuBar_(menuBar),
+	menuEventHandler_(menuEventHandler)
+{ /*empty*/ }
+#endif
+
+Menu::~Menu()
+{
+
+}
+
+void Menu::onEvent(
+    void *event_handler_arg,
+    esp_event_base_t event_base,
+    int32_t event_id,
+    void *event_data)
+{
+    if (event_base == MENU_EVENT)
+    {
+	UI::AbstractMenuBar::EventData *eventData =
+	    reinterpret_cast<UI::AbstractMenuBar::EventData*>(event_data);
+
+      	if (eventData && eventData->self == menuBar_.get())
+      	{
+   	    menuEventHandler_(*menuBar_, *eventData);
+      	}
+   }
+}

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -6,7 +6,7 @@ namespace UI
         area_(area),
         parent_(parent),
         child_(nullptr),
-        nextSibbling_(nullptr),
+        nextSibling_(nullptr),
         faceColor_(DefaultFaceColor),
 	hidden_(false)
     {
@@ -14,7 +14,7 @@ namespace UI
 
             Widget * firstChild = parent_->child_;
             if (firstChild) {
-                nextSibbling_ = firstChild;
+                nextSibling_ = firstChild;
             }
             parent->child_ = this;
         }
@@ -34,19 +34,21 @@ namespace UI
 
             while(child && child != this) {
                 previousChild = child;
-                child = child ->nextSibbling_;
+                child = child ->nextSibling_;
             }
 
             if(previousChild && child) {
-                previousChild ->nextSibbling_ = nextSibbling_;
+                previousChild ->nextSibling_ = nextSibling_;
             } else if( child ) {
-                parent_->child_ = nextSibbling_;
+                parent_->child_ = nextSibling_;
             } // else the child was not found which would be an inconsistency error and should never happen
         }
     }
 
     void Widget::redraw(TFT_eSprite &drawBuffer, const Rect &clientArea) const
     {
+	if (hidden_) return;
+
         Rect const newClientArea = clientArea.intersect(area_);
 
         if(newClientArea.isValid())
@@ -56,7 +58,7 @@ namespace UI
             Widget const * child = child_;
             while(child) {
                 child->redraw(drawBuffer,newClientArea);
-                child = child->nextSibbling_;
+                child = child->nextSibling_;
             }
         }
     }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -7,7 +7,8 @@ namespace UI
         parent_(parent),
         child_(nullptr),
         nextSibbling_(nullptr),
-        faceColor_(DefaultFaceColor)
+        faceColor_(DefaultFaceColor),
+	hidden_(false)
     {
         if (parent_) {
 


### PR DESCRIPTION
This pull request adds the possibility to use multiple menus (which may be called from choosing a menu entry item or any other event).

To do so it adds a `Menu` class that aggregates an `AbstractMenuBar` and a `EventHandler`.
Currently it is governed that only one `Menu` can be drawn at a time, with the same menu solely responding to keyboard input events.

A `DrawDelegator`class was added to allow an aggregator class to delegate draw calls from a parent widget to a held child element.


(This is currently a draft because it is still undergoing testing.)