### PR TITLE
8 restore the state of the keyboard leds before and after a password input

### DIFF
--- a/include/application.hpp
+++ b/include/application.hpp
@@ -11,7 +11,7 @@ class Application: public Widget
 
         static Rect getFullFrameRect() {return Rect(0,0,TFT_HEIGHT,TFT_WIDTH).toLogical(); }
 
-        void update();
+        virtual void update();
 
     private:
         TFT_eSPI tft_;

--- a/include/keyboard.hpp
+++ b/include/keyboard.hpp
@@ -29,6 +29,7 @@ class UsbKeyboard
         bool isCapsLockSet() const { return leds_.capslock != 0; }
         bool isNumLockSet() const { return leds_.numlock != 0; }
         bool isScrollLockSet() const { return leds_.scrolllock != 0; }
+        bool ledsNeedReset() const { return leds_.leds != initialState_.leds; }
 
         void sendKeyStrokes(KeyStrokeFile &input);
 

--- a/include/keyboard.hpp
+++ b/include/keyboard.hpp
@@ -32,13 +32,17 @@ class UsbKeyboard
 
         void sendKeyStrokes(KeyStrokeFile &input);
 
+        void restoreOriginalLedState();
+
         void tick() { button_.tick(); }
 
     private:
         USBHIDKeyboard keyBoard_;
         arduino_usb_hid_keyboard_event_data_t leds_;
+        arduino_usb_hid_keyboard_event_data_t initialState_;
         OneButton button_;
         bool isFirstUpdate_;
+        bool ledRestoreInProgress_;
 
         void onLedStateChange(arduino_usb_hid_keyboard_event_data_t const);
 

--- a/include/passkey_app.hpp
+++ b/include/passkey_app.hpp
@@ -17,11 +17,27 @@ class PassKeyApplication: public UI::Application
         void updateStatusBar(UsbKeyboard::EventData const * const);
 
     private:
+        enum class ApplicationState
+        {
+            SelectPassword,
+            ResetLedsBeforePassword,
+            TypePassword,
+            ResetLedsAfterPassword
+        };
+
         UsbKeyboard keyboard_;
         Statusbar statusBar_;
         UI::Menu typekeyMenu_;
+        ApplicationState state_;
+        ApplicationState previousState_;
+        String selectedItem_;
 
         UI::AbstractMenuBar::MenuItems loadDirectoryContent();
         void onMenuEvent(UI::AbstractMenuBar& menuBar, UI::AbstractMenuBar::EventData const& eventData);
         UI::Rect getMenuArea() const;
+
+        void handleSelectPassword();
+        void handleResetLedsBeforePassword();
+        void handleTypePassword();
+        void handleResetLedsAfterPassword();
 };

--- a/include/passkey_app.hpp
+++ b/include/passkey_app.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "application.hpp"
+#include "keyboard.hpp"
+#include "statusbar.hpp"
+#include "menu.hpp"
+#include "themes.hpp"
+
+class PassKeyApplication: public UI::Application
+{
+    public:
+        PassKeyApplication(UI::Theme const& theme);
+        virtual ~PassKeyApplication();
+
+        void update() override;
+
+        void updateStatusBar(UsbKeyboard::EventData const * const);
+
+    private:
+        UsbKeyboard keyboard_;
+        Statusbar statusBar_;
+        UI::Menu typekeyMenu_;
+
+        UI::AbstractMenuBar::MenuItems loadDirectoryContent();
+        void onMenuEvent(UI::AbstractMenuBar& menuBar, UI::AbstractMenuBar::EventData const& eventData);
+        UI::Rect getMenuArea() const;
+};

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -61,7 +61,8 @@ UsbKeyboard::UsbKeyboard(bool const skipUsb):
 
 UsbKeyboard::~UsbKeyboard()
 {
-    /*@TODO find the unregister event handler function...*/
+    /* If you get here ... not good, as there is no way to unregister (usb event loop is private 
+       and allows only to register):( we will crash soon than ...*/
     keyBoard_.end();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,50 +2,16 @@
 #include <TFT_eSPI.h>
 
 #include <aes/esp_aes.h>
-#include <sdcard.hpp>
 
 #include <list>
 #include <string_view>
 
-#include "ec1834.hpp"
-#include "widget.hpp"
-#include "statusbar.hpp"
-#include "application.hpp"
-#include "menu.hpp"
-#include "keyboard.hpp"
+#include "passkey_app.hpp"
 #include "themes.hpp"
 #include "macros.hpp"
 #include "config.hpp"
 
-static UI::Application *application;
-static UI::Menu * typekeyMenu;
-static Statusbar *statusBar;
-static std::shared_ptr<SDCard> sdCard;
-static UI::AbstractMenuBar::MenuItems menuItems;
-static UsbKeyboard *keyboard;
-
-
-static void loadDirectoryContent(void)
-{
-  std::shared_ptr<DIR> directory = sdCard->openDir("");
-
-  dirent *dir;
-  while((dir = readdir(directory.get())))
-  {
-      if(DT_REG == dir->d_type)
-      {
-            if (dir->d_name != configFileName())
-	    {
-                menuItems.emplace_back(String(dir->d_name));
-	    }
-      }
-  }
-
-  if(menuItems.empty()) {
-    menuItems.emplace_back(String("No Files found"));
-  }
-}
-
+static PassKeyApplication *application;
 
 static void onLedUpdate(void *event_handler_arg,
                            esp_event_base_t event_base,
@@ -54,12 +20,7 @@ static void onLedUpdate(void *event_handler_arg,
 {
   if(event_base == KEYBOARD_EVENT && event_id == UsbKeyboard::LedsUpdated) {
       UsbKeyboard::EventData *event = reinterpret_cast<UsbKeyboard::EventData *>(event_data);
-      if(event)
-      {
-          statusBar->setCapsLockStatus(event->self->isCapsLockSet());
-          statusBar->setNumLockStatus(event->self->isNumLockSet());
-          statusBar->setScrollLockStatus(event->self->isScrollLockSet());
-      }
+      application->updateStatusBar(event);
   }
 }
 
@@ -70,68 +31,33 @@ static constexpr std::string_view themeDefault_ = "robotron";
     static constexpr std::string_view themeSet_ = PASSKEY_STRINGIZE(PASSKEY_THEME);
 #endif // PASSKEY_THEME
 
-
-static void setupThemedElements(
-	UI::Theme const& theme,
-	UI::Rect const& screen,
-	UI::AbstractMenuBar::MenuItems const& items,
-	UI::Application * const parent)
-{
-    statusBar = new Statusbar(0, theme, parent);
-    typekeyMenu = new UI::Menu(
-        [](
-	    UI::AbstractMenuBar& menuBar,
-	    UI::AbstractMenuBar::EventData const& eventData)
-	{
-	    KeyStrokeFile file(sdCard->open(menuBar.selectedItem(), SDCard::OpenMode::FILE_READONLY));
-	    keyboard->sendKeyStrokes(file);
-	},
-	parent,
-	/* VerticalMenuBar initialization starting from here */
-	UI::VerticalMenu,
-	items,
-	UI::Rect(0, 1, screen.width, screen.height - 1),
-	theme,
-	0
-    );
-    typekeyMenu->makeActive();
-}
-
-
 void setup()
 {
     esp_event_loop_create_default();
     esp_event_handler_register(KEYBOARD_EVENT, UsbKeyboard::LedsUpdated, onLedUpdate, NULL);
 
-    sdCard = SDCard::load();
-    loadDirectoryContent();
-    UI::Rect fullScreen = UI::Application::getFullFrameRect();
-    application = new UI::Application();
     try
     {
         if constexpr (themeSet_ == "random")
         {
 	      auto it = UI::themes().begin();
 	      std::advance(it, random(UI::themes().size()));
-	      setupThemedElements(it->second, fullScreen, menuItems, application);
+          application = new PassKeyApplication(it->second);
         }
         else
         {
 	      UI::Theme const& theme = UI::themes().at(String(themeSet_.data()));
-	      setupThemedElements(theme, fullScreen, menuItems, application);
+          application = new PassKeyApplication(theme);
         }
     }
     catch (std::out_of_range)
     {
         UI::Theme const& theme = UI::themes().at(String(themeDefault_.data()));
-        setupThemedElements(theme, fullScreen, menuItems, application);
+        application = new PassKeyApplication(theme);
     }
-    keyboard = new UsbKeyboard(false);
 }
 
-unsigned count = 0;
 void loop() {
-  keyboard->tick();
 
   application->update();
 

--- a/src/passkey_app.cpp
+++ b/src/passkey_app.cpp
@@ -1,0 +1,84 @@
+#include "passkey_app.hpp"
+#include "sdcard.hpp"
+#include "config.hpp"
+
+#include <functional>
+
+PassKeyApplication::PassKeyApplication(UI::Theme const& theme): UI::Application(),
+    keyboard_(false),
+    statusBar_(0, theme, this),
+    typekeyMenu_(
+        [this]( UI::AbstractMenuBar& menuBar, UI::AbstractMenuBar::EventData const& eventData)
+	    {
+            onMenuEvent(menuBar, eventData);
+        }, 
+        this, 
+        UI::VerticalMenu, 
+        loadDirectoryContent(), 
+        getMenuArea(),
+        theme, 
+        0)
+{
+    typekeyMenu_.makeActive();
+}
+
+PassKeyApplication::~PassKeyApplication()
+{
+}
+
+void PassKeyApplication::update()
+{
+    UI::Application::update(); //Call the update from the base class
+
+    keyboard_.tick(); // Tick the Keyboard here
+}
+
+void PassKeyApplication::updateStatusBar(UsbKeyboard::EventData const * const event)
+{
+    if(event)
+    {
+        statusBar_.setCapsLockStatus(event->self->isCapsLockSet());
+        statusBar_.setNumLockStatus(event->self->isNumLockSet());
+        statusBar_.setScrollLockStatus(event->self->isScrollLockSet());
+    }
+}
+
+UI::AbstractMenuBar::MenuItems PassKeyApplication::loadDirectoryContent()
+{
+  UI::AbstractMenuBar::MenuItems result;
+  std::shared_ptr<SDCard> sdCard = SDCard::load();
+  std::shared_ptr<DIR> directory = sdCard->openDir("");
+
+  dirent *dir;
+  while((dir = readdir(directory.get())))
+  {
+      if(DT_REG == dir->d_type)
+      {
+            if (dir->d_name != configFileName())
+	    {
+                result.emplace_back(String(dir->d_name));
+	    }
+      }
+  }
+
+  if(result.empty()) {
+    result.emplace_back(String("No Files found"));
+  }
+
+  return result;
+}
+
+void PassKeyApplication::onMenuEvent(UI::AbstractMenuBar &menuBar, UI::AbstractMenuBar::EventData const &eventData)
+{
+    	std::shared_ptr<SDCard> sdCard = SDCard::load();
+        KeyStrokeFile file(sdCard->open(menuBar.selectedItem(), SDCard::OpenMode::FILE_READONLY));
+        keyboard_.restoreOriginalLedState();
+	    keyboard_.sendKeyStrokes(file);
+}
+
+UI::Rect PassKeyApplication::getMenuArea() const
+{
+    UI::Rect screen = getFullFrameRect();
+    
+    return UI::Rect(0,1,screen.width, screen.height -1);
+}


### PR DESCRIPTION
This will close the issue #8 if merged.

Open Points:
* [x] Implement a reset function in the keyboard class
* [x] Implement a state machine, to wait for the Client to respond to the LED reset requests before sending the password.
* [x] Reset the LED state also after sending the password
* [x] Find the event unregister function for the keyboard in the undocumented arduino API to prevent crashes, when the keyboard is unloaded