### PR TITLE
Switching between Applications

### DIFF
--- a/include/application.hpp
+++ b/include/application.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <widget.hpp>
+#include "keyboard.hpp"
 
 namespace UI {
 class Application: public Widget
@@ -11,5 +12,8 @@ class Application: public Widget
         static Rect getFullFrameRect() {return Rect(0,0,TFT_HEIGHT,TFT_WIDTH).toLogical(); }
 
         virtual void update();
+
+    protected:
+        UsbKeyboard& keyboard_;
 };
 }

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -7,7 +7,7 @@ namespace UI {
 class Application: public Widget
 {
     public:
-        Application();
+        Application(Application * parent = nullptr);
 
         static Rect getFullFrameRect() {return Rect(0,0,TFT_HEIGHT,TFT_WIDTH).toLogical(); }
 

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <TFT_eSPI.h>
 #include <widget.hpp>
 
 namespace UI {
@@ -12,9 +11,5 @@ class Application: public Widget
         static Rect getFullFrameRect() {return Rect(0,0,TFT_HEIGHT,TFT_WIDTH).toLogical(); }
 
         virtual void update();
-
-    private:
-        TFT_eSPI tft_;
-        TFT_eSprite backBuffer_;
 };
 }

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -58,6 +58,7 @@ class AppLoaderApplication: public UI::Application
 
         void load(unsigned index = 0);
         void unload();
+        void rotate();
 
     protected:
         virtual void onNotify(Widget* requestOrigin, UI::NotificationCode code) override;

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "application.hpp"
+#include "keyboard.hpp"
+#include "menu.hpp"
+#include "themes.hpp"
+
+#include <memory>
+#include <functional>
+
+class AbstractAppItem
+{
+    protected:
+        String name_;
+
+    public:
+        AbstractAppItem(String name)
+        :   name_(name)
+        {}
+
+        String const& getName()
+        {
+            return name_;
+        }
+
+        virtual std::shared_ptr<UI::Application> create() = 0;
+};
+
+
+template <class ApplicationClass, class... Ts>
+class AppItem : public AbstractAppItem
+{
+    private:
+        std::tuple<Ts...> args_;
+
+    public:
+        AppItem(
+            String const& name,
+            Ts... applicationArgs)
+            :   AbstractAppItem(name),
+                args_(std::forward<Ts>(applicationArgs)...)
+        {}
+
+       virtual std::shared_ptr<UI::Application> create() override
+       {
+           return std::apply(std::make_shared<ApplicationClass, std::add_lvalue_reference_t<Ts>...>, args_);
+       }
+};
+
+
+class AppLoaderApplication: public UI::Application
+{
+    public:
+        AppLoaderApplication(std::initializer_list<AbstractAppItem*> appItems);
+        virtual ~AppLoaderApplication();
+
+        void update() override;
+
+        void load(unsigned index = 0);
+        void unload();
+
+    protected:
+        virtual void onNotify(Widget* requestOrigin, UI::NotificationCode code) override;
+
+
+    private:
+        std::vector<AbstractAppItem*> apps_; // Front is active app
+
+        std::shared_ptr<UI::Application> currentApp_;
+        AbstractAppItem* suspendedApp_;
+
+        bool doUnload_;
+        bool doSuspend_;
+};
+

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -65,6 +65,8 @@ class AppLoaderApplication: public UI::Application
         void unload();
         void rotate();
 
+        virtual void onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * event);
+
     protected:
         virtual void onNotify(Widget* requestOrigin, UI::NotificationCode code) override;
 

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -23,7 +23,7 @@ class AbstractAppItem
             return name_;
         }
 
-        virtual std::shared_ptr<UI::Application> create() = 0;
+        virtual std::shared_ptr<UI::Application> create(UI::Application * parent) = 0;
 };
 
 
@@ -41,9 +41,14 @@ class AppItem : public AbstractAppItem
                 args_(std::forward<Ts>(applicationArgs)...)
         {}
 
-       virtual std::shared_ptr<UI::Application> create() override
+       virtual std::shared_ptr<UI::Application> create(UI::Application * parent = nullptr) override
        {
-           return std::apply(std::make_shared<ApplicationClass, std::add_lvalue_reference_t<Ts>...>, args_);
+            auto argsAndParent = std::tuple_cat(args_, std::make_tuple(parent));
+            return std::apply(
+                std::make_shared<
+                    ApplicationClass,
+                    std::add_lvalue_reference_t<Ts>..., UI::Application*&
+                >, argsAndParent);
        }
 };
 

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -71,6 +71,5 @@ class AppLoaderApplication: public UI::Application
         AbstractAppItem* suspendedApp_;
 
         bool doUnload_;
-        bool doSuspend_;
 };
 

--- a/include/apploader_app.hpp
+++ b/include/apploader_app.hpp
@@ -71,9 +71,7 @@ class AppLoaderApplication: public UI::Application
 
     private:
         std::vector<AbstractAppItem*> apps_; // Front is active app
-
         std::shared_ptr<UI::Application> currentApp_;
-        AbstractAppItem* suspendedApp_;
 
         bool doUnload_;
 };

--- a/include/passkey_app.hpp
+++ b/include/passkey_app.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "application.hpp"
-#include "keyboard.hpp"
 #include "statusbar.hpp"
 #include "menu.hpp"
 #include "themes.hpp"
@@ -25,7 +24,6 @@ class PassKeyApplication: public UI::Application
             ResetLedsAfterPassword
         };
 
-        UsbKeyboard keyboard_;
         Statusbar statusBar_;
         UI::Menu typekeyMenu_;
         ApplicationState state_;

--- a/include/passkey_app.hpp
+++ b/include/passkey_app.hpp
@@ -14,7 +14,7 @@ class PassKeyApplication: public UI::Application
 
         void update() override;
 
-        void updateStatusBar(UsbKeyboard::EventData const * const);
+        virtual void onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * event) override;
 
     private:
         enum class ApplicationState

--- a/include/passkey_app.hpp
+++ b/include/passkey_app.hpp
@@ -9,7 +9,7 @@
 class PassKeyApplication: public UI::Application
 {
     public:
-        PassKeyApplication(UI::Theme const& theme);
+        PassKeyApplication(UI::Theme const& theme, UI::Application * parent = nullptr);
         virtual ~PassKeyApplication();
 
         void update() override;

--- a/include/widget.hpp
+++ b/include/widget.hpp
@@ -11,8 +11,7 @@
 namespace UI {
     // NotificationCodes for interaction between widgets
     enum class NotificationCode {
-        DESTROY_ME, // Request deconstrution at parent level
-        SUSPEND_ME // Request suspension at parent level
+        DESTROY_ME // Request deconstrution at parent level
     };
 
     class Widget

--- a/include/widget.hpp
+++ b/include/widget.hpp
@@ -2,6 +2,7 @@
 
 #include <TFT_eSPI.h>
 
+#include <keyboard.hpp>
 #include <rect.hpp>
 #include <colors.hpp>
 #include <themes.hpp>
@@ -38,6 +39,8 @@ namespace UI {
         {
             if (parent_ != nullptr) parent_->onNotify(this, code);
         }
+
+        virtual void onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * event);
 
         protected:
         virtual void draw(TFT_eSprite &drawBuffer, const Rect &clientArea) const;

--- a/include/widget.hpp
+++ b/include/widget.hpp
@@ -8,6 +8,12 @@
 
 
 namespace UI {
+    // NotificationCodes for interaction between widgets
+    enum class NotificationCode {
+        DESTROY_ME, // Request deconstrution at parent level
+        SUSPEND_ME // Request suspension at parent level
+    };
+
     class Widget
     {
         public:
@@ -21,21 +27,27 @@ namespace UI {
 
         virtual void setTheme(Theme const& theme) { faceColor_ = theme.colors.background; }
 
-	void setHidden(bool hidden) { hidden_ = hidden; }
-	bool isHidden() { return hidden_; }
+        void setHidden(bool hidden) { hidden_ = hidden; }
+        bool isHidden() { return hidden_; }
 
         void moveTo(int x, int y) { area_.x = x; area_.y = y; }
 
-	Widget const * getSibling() const {return nextSibling_;}
+        Widget const * getSibling() const {return nextSibling_;}
+
+        void notifyParent(NotificationCode code)
+        {
+            if (parent_ != nullptr) parent_->onNotify(this, code);
+        }
 
         protected:
         virtual void draw(TFT_eSprite &drawBuffer, const Rect &clientArea) const;
+        virtual void onNotify(Widget* requestOrigin, NotificationCode code);
 
         Rect area_;
         Widget * parent_;
         Widget * child_;
         Widget * nextSibling_;
         Color faceColor_;
-	bool hidden_;
+        bool hidden_;
     };
 }

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -6,10 +6,12 @@ static TFT_eSPI tft_;
 static TFT_eSprite backBuffer_(&tft_);
 static bool tftInitialized_ = false;
 
+static UsbKeyboard * usbKeyboard_ = nullptr; // will get initialized the first time an application is instantiated
 
 namespace UI {
     Application::Application(Application * parent):
-        Widget(getFullFrameRect(), parent)
+        Widget(getFullFrameRect(), parent),
+        keyboard_(usbKeyboard_ ? *usbKeyboard_ : *(new UsbKeyboard(false)) )
     {
         if (!tftInitialized_)
         {
@@ -28,11 +30,16 @@ namespace UI {
             ec1834bin_select(tft_);
             tftInitialized_ = true;
         }
+
+        // Register keyboard for the case a new one got created
+        usbKeyboard_ = &keyboard_;
     }
 
     void Application::update()
     {
         redraw(backBuffer_, getFullFrameRect());
         backBuffer_.pushSprite(0,0);
+
+        keyboard_.tick(); // Tick the Keyboard here
     }
 }

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -2,8 +2,8 @@
 #include "ec1834.hpp"
 
 namespace UI {
-    Application::Application():
-        Widget(getFullFrameRect()),
+    Application::Application(Application * parent):
+        Widget(getFullFrameRect(), parent),
         tft_(),
         backBuffer_(&tft_)
     {

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,25 +1,33 @@
 #include "application.hpp"
 #include "ec1834.hpp"
+#include <TFT_eSPI.h>
+
+static TFT_eSPI tft_;
+static TFT_eSprite backBuffer_(&tft_);
+static bool tftInitialized_ = false;
+
 
 namespace UI {
     Application::Application(Application * parent):
-        Widget(getFullFrameRect(), parent),
-        tft_(),
-        backBuffer_(&tft_)
+        Widget(getFullFrameRect(), parent)
     {
-        tft_.init();
+        if (!tftInitialized_)
+        {
+            tft_.init();
 
-        backBuffer_.createSprite(TFT_HEIGHT, TFT_WIDTH);
-        backBuffer_.setAttribute(UTF8_SWITCH,0);
-        backBuffer_.fillScreen(TFT_BLACK);
-        backBuffer_.setTextColor(TFT_GREEN, TFT_BLACK);
-        ec1834bin_select(backBuffer_);
+            backBuffer_.createSprite(TFT_HEIGHT, TFT_WIDTH);
+            backBuffer_.setAttribute(UTF8_SWITCH,0);
+            backBuffer_.fillScreen(TFT_BLACK);
+            backBuffer_.setTextColor(TFT_GREEN, TFT_BLACK);
+            ec1834bin_select(backBuffer_);
 
-        tft_.setAttribute(UTF8_SWITCH,0);
-        tft_.setRotation(1);
-        tft_.fillScreen(TFT_BLACK);
-        tft_.setTextColor(TFT_GREEN, TFT_BLACK);
-        ec1834bin_select(tft_);
+            tft_.setAttribute(UTF8_SWITCH,0);
+            tft_.setRotation(1);
+            tft_.fillScreen(TFT_BLACK);
+            tft_.setTextColor(TFT_GREEN, TFT_BLACK);
+            ec1834bin_select(tft_);
+            tftInitialized_ = true;
+        }
     }
 
     void Application::update()

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -1,0 +1,60 @@
+#include "apploader_app.hpp"
+#include "config.hpp"
+
+#include <functional>
+
+AppLoaderApplication::AppLoaderApplication(std::initializer_list<AbstractAppItem*> appItems): UI::Application(),
+    suspendedApp_(nullptr),
+    doUnload_(false),
+    doSuspend_(false)
+{
+}
+
+AppLoaderApplication::~AppLoaderApplication()
+{
+}
+
+void AppLoaderApplication::update()
+{
+    if (doUnload_)
+    {
+        unload();
+        doUnload_ = false;
+    }
+
+    if (currentApp_)
+    {
+        currentApp_->update();
+    }
+    else
+    {
+        UI::Application::update(); // Call the update from the base class
+    }
+}
+
+
+void AppLoaderApplication::load(unsigned index)
+{
+    currentApp_ = apps_.at(index)->create();
+}
+
+
+void AppLoaderApplication::unload()
+{
+    currentApp_.reset();
+}
+
+
+void AppLoaderApplication::onNotify(Widget* requestOrigin, UI::NotificationCode code)
+{
+    switch (code)
+    {
+        case UI::NotificationCode::DESTROY_ME:
+            doUnload_ = true;
+            break;
+        case UI::NotificationCode::SUSPEND_ME:
+            doSuspend_ = true;
+            break;
+    }
+}
+

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -4,8 +4,8 @@
 #include <functional>
 #include <algorithm>
 
-AppLoaderApplication::AppLoaderApplication(std::initializer_list<AbstractAppItem*> appItems): UI::Application(),
-    suspendedApp_(nullptr),
+AppLoaderApplication::AppLoaderApplication(std::initializer_list<AbstractAppItem*> appItems) :
+    UI::Application(),
     doUnload_(false)
 {
 }

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -52,6 +52,15 @@ void AppLoaderApplication::rotate()
 }
 
 
+void AppLoaderApplication::onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * event)
+{
+    if (currentApp_)
+    {
+        currentApp_->onKeyboardEvent(eventId, event);
+    }
+}
+
+
 void AppLoaderApplication::onNotify(Widget* requestOrigin, UI::NotificationCode code)
 {
     switch (code)

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -36,7 +36,7 @@ void AppLoaderApplication::update()
 
 void AppLoaderApplication::load(unsigned index)
 {
-    currentApp_ = apps_.at(index)->create();
+    currentApp_ = apps_.at(index)->create(this);
 }
 
 

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -8,6 +8,11 @@ AppLoaderApplication::AppLoaderApplication(std::initializer_list<AbstractAppItem
     UI::Application(),
     doUnload_(false)
 {
+    for (AbstractAppItem* appItem : appItems)
+    {
+        apps_.push_back(appItem);
+    }
+    load();
 }
 
 AppLoaderApplication::~AppLoaderApplication()

--- a/src/apploader_app.cpp
+++ b/src/apploader_app.cpp
@@ -2,11 +2,11 @@
 #include "config.hpp"
 
 #include <functional>
+#include <algorithm>
 
 AppLoaderApplication::AppLoaderApplication(std::initializer_list<AbstractAppItem*> appItems): UI::Application(),
     suspendedApp_(nullptr),
-    doUnload_(false),
-    doSuspend_(false)
+    doUnload_(false)
 {
 }
 
@@ -18,7 +18,8 @@ void AppLoaderApplication::update()
 {
     if (doUnload_)
     {
-        unload();
+        rotate();
+        load(); // Loads front and unloads anything else that potentially existed already
         doUnload_ = false;
     }
 
@@ -45,15 +46,18 @@ void AppLoaderApplication::unload()
 }
 
 
+void AppLoaderApplication::rotate()
+{
+    std::rotate(apps_.begin(), apps_.begin() + 1, apps_.end());
+}
+
+
 void AppLoaderApplication::onNotify(Widget* requestOrigin, UI::NotificationCode code)
 {
     switch (code)
     {
         case UI::NotificationCode::DESTROY_ME:
             doUnload_ = true;
-            break;
-        case UI::NotificationCode::SUSPEND_ME:
-            doSuspend_ = true;
             break;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,10 +20,11 @@ using PassKeyAppItem = AppItem<PassKeyApplication, UI::Theme const&>;
 static PassKeyAppItem * passkeyApp;
 
 
-static void onLedUpdate(void *event_handler_arg,
-                           esp_event_base_t event_base,
-                           int32_t event_id,
-                           void *event_data)
+static void propagateKeyboardEvent(
+    void *event_handler_arg,
+    esp_event_base_t event_base,
+    int32_t event_id,
+    void *event_data)
 {
   if (event_base == KEYBOARD_EVENT) {
       UsbKeyboard::EventData *event = reinterpret_cast<UsbKeyboard::EventData *>(event_data);
@@ -41,7 +42,11 @@ static constexpr std::string_view themeDefault_ = "robotron";
 void setup()
 {
     esp_event_loop_create_default();
-    esp_event_handler_register(KEYBOARD_EVENT, UsbKeyboard::LedsUpdated, onLedUpdate, NULL);
+    esp_event_handler_register(
+        KEYBOARD_EVENT,
+        UsbKeyboard::LedsUpdated,
+        propagateKeyboardEvent,
+        NULL);
 
     try
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,6 @@ void setup()
     application = new AppLoaderApplication{
         passkeyApp
     };
-    application->load();
 }
 
 void loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,11 @@
 #include "macros.hpp"
 #include "config.hpp"
 
-static AppLoaderApplication *application;
+static AppLoaderApplication* application;
 
 // Available Apps
 using PassKeyAppItem = AppItem<PassKeyApplication, UI::Theme const&>;
-static PassKeyAppItem * passkeyApp;
+static PassKeyAppItem* passkeyApp;
 
 
 static void propagateKeyboardEvent(
@@ -26,7 +26,8 @@ static void propagateKeyboardEvent(
     int32_t event_id,
     void *event_data)
 {
-  if (event_base == KEYBOARD_EVENT) {
+  if (event_base == KEYBOARD_EVENT)
+  {
       UsbKeyboard::EventData *event = reinterpret_cast<UsbKeyboard::EventData *>(event_data);
       application->onKeyboardEvent(event_id, event);
   }
@@ -52,14 +53,14 @@ void setup()
     {
         if constexpr (themeSet_ == "random")
         {
-          auto it = UI::themes().begin();
-          std::advance(it, random(UI::themes().size()));
-          passkeyApp = new PassKeyAppItem("Passkey", it->second);
+            auto it = UI::themes().begin();
+            std::advance(it, random(UI::themes().size()));
+            passkeyApp = new PassKeyAppItem("Passkey", it->second);
         }
         else
         {
-          UI::Theme const& theme = UI::themes().at(String(themeSet_.data()));
-          passkeyApp = new PassKeyAppItem("Passkey", theme);
+            UI::Theme const& theme = UI::themes().at(String(themeSet_.data()));
+            passkeyApp = new PassKeyAppItem("Passkey", theme);
         }
     }
     catch (std::out_of_range)
@@ -69,14 +70,13 @@ void setup()
     }
 
     application = new AppLoaderApplication{
-         passkeyApp
+        passkeyApp
     };
     application->load();
 }
 
-void loop() {
-
-  application->update();
-
-  delay(5);
+void loop()
+{
+    application->update();
+    delay(5);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,9 @@ static void onLedUpdate(void *event_handler_arg,
                            int32_t event_id,
                            void *event_data)
 {
-  if(event_base == KEYBOARD_EVENT && event_id == UsbKeyboard::LedsUpdated) {
+  if (event_base == KEYBOARD_EVENT) {
       UsbKeyboard::EventData *event = reinterpret_cast<UsbKeyboard::EventData *>(event_data);
-      // application->updateStatusBar(event); // TODO Readd
+      application->onKeyboardEvent(event_id, event);
   }
 }
 

--- a/src/passkey_app.cpp
+++ b/src/passkey_app.cpp
@@ -5,7 +5,6 @@
 #include <functional>
 
 PassKeyApplication::PassKeyApplication(UI::Theme const& theme, Application * parent): UI::Application(parent),
-    keyboard_(false),
     statusBar_(0, theme, this),
     typekeyMenu_(
         [this]( UI::AbstractMenuBar& menuBar, UI::AbstractMenuBar::EventData const& eventData)
@@ -44,8 +43,6 @@ void PassKeyApplication::update()
     }
 
     previousState_ = state_;
-
-    keyboard_.tick(); // Tick the Keyboard here
 }
 
 void PassKeyApplication::onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * const event)

--- a/src/passkey_app.cpp
+++ b/src/passkey_app.cpp
@@ -48,9 +48,9 @@ void PassKeyApplication::update()
     keyboard_.tick(); // Tick the Keyboard here
 }
 
-void PassKeyApplication::updateStatusBar(UsbKeyboard::EventData const * const event)
+void PassKeyApplication::onKeyboardEvent(int32_t eventId, UsbKeyboard::EventData const * const event)
 {
-    if(event)
+    if (eventId == UsbKeyboard::LedsUpdated && event)
     {
         statusBar_.setCapsLockStatus(event->self->isCapsLockSet());
         statusBar_.setNumLockStatus(event->self->isNumLockSet());

--- a/src/passkey_app.cpp
+++ b/src/passkey_app.cpp
@@ -67,9 +67,9 @@ UI::AbstractMenuBar::MenuItems PassKeyApplication::loadDirectoryContent()
       if(DT_REG == dir->d_type)
       {
             if (dir->d_name != configFileName())
-        {
+            {
                 result.emplace_back(String(dir->d_name));
-        }
+            }
       }
   }
 

--- a/src/passkey_app.cpp
+++ b/src/passkey_app.cpp
@@ -4,12 +4,12 @@
 
 #include <functional>
 
-PassKeyApplication::PassKeyApplication(UI::Theme const& theme): UI::Application(),
+PassKeyApplication::PassKeyApplication(UI::Theme const& theme, Application * parent): UI::Application(parent),
     keyboard_(false),
     statusBar_(0, theme, this),
     typekeyMenu_(
         [this]( UI::AbstractMenuBar& menuBar, UI::AbstractMenuBar::EventData const& eventData)
-	    {
+        {
             onMenuEvent(menuBar, eventData);
         }, 
         this, 
@@ -70,9 +70,9 @@ UI::AbstractMenuBar::MenuItems PassKeyApplication::loadDirectoryContent()
       if(DT_REG == dir->d_type)
       {
             if (dir->d_name != configFileName())
-	    {
+        {
                 result.emplace_back(String(dir->d_name));
-	    }
+        }
       }
   }
 
@@ -124,7 +124,7 @@ void PassKeyApplication::handleTypePassword()
     {
         std::shared_ptr<SDCard> sdCard = SDCard::load();
         KeyStrokeFile file(sdCard->open(selectedItem_, SDCard::OpenMode::FILE_READONLY));
-	    keyboard_.sendKeyStrokes(file);
+        keyboard_.sendKeyStrokes(file);
 
         state_ = ApplicationState::ResetLedsAfterPassword;
     }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -8,7 +8,7 @@ namespace UI
         child_(nullptr),
         nextSibling_(nullptr),
         faceColor_(DefaultFaceColor),
-    hidden_(false)
+        hidden_(false)
     {
         if (parent_) {
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -73,4 +73,9 @@ namespace UI
     {
         // Default action is to do nothing
     }
+
+    void Widget::onKeyboardEvent(int32_t, UsbKeyboard::EventData const *)
+    {
+        // Default action is to do nothing
+    }
 }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -8,7 +8,7 @@ namespace UI
         child_(nullptr),
         nextSibling_(nullptr),
         faceColor_(DefaultFaceColor),
-	hidden_(false)
+    hidden_(false)
     {
         if (parent_) {
 
@@ -47,7 +47,7 @@ namespace UI
 
     void Widget::redraw(TFT_eSprite &drawBuffer, const Rect &clientArea) const
     {
-	if (hidden_) return;
+    if (hidden_) return;
 
         Rect const newClientArea = clientArea.intersect(area_);
 
@@ -67,5 +67,10 @@ namespace UI
     {
         Rect area = clientArea.toScreen();
         drawBuffer.fillRect(area.x, area.y, area.width, area.height, faceColor_);
+    }
+
+    void Widget::onNotify(Widget*, NotificationCode)
+    {
+        // Default action is to do nothing
     }
 }


### PR DESCRIPTION
This adds an `AppLoaderApplication` class that serves as the root application to manage further child applications. With this change it will be possible to implement the lockscreen (see https://github.com/DGhost001/passkey/issues/4) as another application that is loaded once other applications deem it appropriate.

The `AppLoaderApplication` holds the arguments needed to create a child application instance. These instances are initialized once they are active and deconstructed once they become inactive.

Once a child applications closes, the next application in the chain is made active.

For this functionality, a notification scheme is added with which the child can request being closed by the parent (`notifyParent`). Furthermore, the keyboard event-handling is generalized for all widgets via a base interface (`onKeyboardEvent`).
