### PR TITLE
Fix Application not Running because of Recent Framework Version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:lilygo-t-display-s3]
-platform = espressif32
+platform = espressif32 @ 6.5.0
 #board = lilygo-t-display-s3
 board = esp32-s3-devkitc-1
 #platform_packages = framework-arduinoespressif32@https://github.com/espressif/arduino-esp32.git#2.0.5

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,21 +21,21 @@ framework = arduino
 # Unflag gnu++11 so gnu++17 is actually used
 build_unflags =
     -std=gnu++11
-build_flags = 
+build_flags =
     ; -DBOARD_HAS_PSRAM
     -std=gnu++17
     -DPASSKEY_THEME=robotron
     -DARDUINO_USB_MODE=1
-    -DARDUINO_USB_CDC_ON_BOOT=1 
+    -DARDUINO_USB_CDC_ON_BOOT=1
     -D USER_SETUP_LOADED
     -D ST7735_DRIVER
     -D SPI_FREQUENCY=50000000
     -D TFT_MISO=-1
     -D TFT_MOSI=3
     -D TFT_SCLK=5
-    -D TFT_CS=4 
-    -D TFT_DC=2 
-    -D TFT_RST=1 
+    -D TFT_CS=4
+    -D TFT_DC=2
+    -D TFT_RST=1
     -D TFT_WIDTH=80
     -D TFT_HEIGHT=160
     -D ST7735_GREENTAB160x80


### PR DESCRIPTION
The most recent versions of the espressif framework cause the passkey to malfunction, with it being stuck on black screen.

Pinning the framework to an earlier version fixes this issue and allows it to work as before.